### PR TITLE
Read pages as UTF-8, and survive printing what they contain

### DIFF
--- a/tools/deslop.py
+++ b/tools/deslop.py
@@ -203,6 +203,14 @@ def report(hits, label='', allow_proof=False):
 
 
 if __name__ == '__main__':
+    # Reading UTF-8 correctly means real non-ASCII now reaches print(), and a
+    # Windows console is cp1252: one CJK character or emoji inside a flagged
+    # snippet used to end the run in a UnicodeEncodeError traceback. Replace
+    # rather than raise — the job is to name the tell, not to echo it perfectly.
+    try:
+        sys.stdout.reconfigure(errors='replace')
+    except (AttributeError, ValueError):  # already-wrapped or exotic stream
+        pass
     args = sys.argv[1:]
     if not args:
         sys.exit(__doc__)
@@ -214,7 +222,13 @@ if __name__ == '__main__':
         text = ' '.join(args[1:])
     else:
         try:
-            html = open(args[0]).read()
+            # Encoding is explicit because open() otherwise uses the locale's,
+            # which is cp1252 on a stock Windows install. A UTF-8 page then
+            # decodes em-dashes and curly apostrophes into mojibake, and the
+            # punctuation and construction rules go silently blind: the same
+            # copy scored 4/5 through --text and 5/5 CLEAN from a file. A gate
+            # that passes because it cannot read is worse than no gate.
+            html = open(args[0], encoding='utf-8', errors='replace').read()
         except (FileNotFoundError, IsADirectoryError, PermissionError) as e:
             sys.exit(f'deslop: cannot read {args[0]}: {e.strerror}')
         if '--view' in args:

--- a/tools/test_deslop.py
+++ b/tools/test_deslop.py
@@ -7,6 +7,7 @@ must-stay-clean case that would break if the rule got greedy.
 """
 import re
 import subprocess
+import tempfile
 import sys
 import os
 
@@ -96,6 +97,37 @@ r = subprocess.run([sys.executable, f'{here}/deslop.py', '/nope/missing.html'],
                    capture_output=True, text=True)
 check('missing file exits non-zero', r.returncode != 0, f'exit {r.returncode}')
 check('missing file has no traceback', 'Traceback' not in r.stderr, r.stderr[:80])
+
+# ── a UTF-8 page is read as UTF-8, whatever the locale ─────────────────
+# open() without an explicit encoding uses the locale's, which is cp1252 on a
+# stock Windows install. The em-dash and curly-apostrophe rules then read
+# mojibake and never fire, so a page full of tells scores CLEAN. Driven through
+# the CLI on purpose: --text was always fine, the file path was the blind spot.
+_dir = tempfile.mkdtemp()
+_utf8 = os.path.join(_dir, 'utf8.html')
+with open(_utf8, 'w', encoding='utf-8') as fh:
+    fh.write('<html><body><p>It’s not just a tool, it’s a platform. '
+             'Whether you’re a startup or an agency, we ship fast — '
+             'really fast — every week.</p></body></html>')
+r = subprocess.run([sys.executable, f'{here}/deslop.py', _utf8],
+                   capture_output=True, text=True, encoding='utf-8', errors='replace')
+check('utf-8 file is not decoded as cp1252', r.returncode != 0,
+      'a UTF-8 page full of tells scored CLEAN — locale decoding is back')
+check('utf-8 file: construction rule fires', 'construction' in r.stdout, r.stdout[:140])
+check('utf-8 file: em-dash rule fires', 'em-dash' in r.stdout, r.stdout[:140])
+
+# ── a flagged snippet outside the console codepage must not crash ──────
+# Reading UTF-8 properly means CJK and emoji reach print(), and a Windows
+# console is cp1252. This used to exit on a UnicodeEncodeError traceback
+# instead of printing a score, which is a crash dressed as a failing gate.
+_cjk = os.path.join(_dir, 'cjk.html')
+with open(_cjk, 'w', encoding='utf-8') as fh:
+    fh.write('<html><body><p>Our seamless platform 你好 — 世界 '
+             '— delivers robust value today.</p></body></html>')
+r = subprocess.run([sys.executable, f'{here}/deslop.py', _cjk],
+                   capture_output=True, text=True, encoding='utf-8', errors='replace')
+check('non-cp1252 snippet does not traceback', 'Traceback' not in r.stderr, r.stderr[-160:])
+check('non-cp1252 snippet still scores', 'score' in r.stdout, r.stdout[:140])
 
 # ── clean human copy still scores 5/5 ───────────────────────────────────────
 for ok in ('Six nails per shingle, every shingle.',


### PR DESCRIPTION
On a stock Windows install, `deslop.py` scores a real page **5/5 CLEAN** when the same
copy through `--text` scores **4/5**. It does not error. It passes.

## The bug

`deslop.py` opens the target file with no `encoding=`, so Python uses the locale's —
`cp1252` on Windows. A UTF-8 page's em-dashes and curly apostrophes decode into mojibake
(`â€"`, `â€™`), so `visible_text`'s `.replace('’', "'")` never fires and `window.count('—')`
counts zero. The punctuation and construction rules match nothing.

```html
<p>It's not just a tool, it's a platform. Whether you're a startup
   or an agency, we ship fast — really fast — every week.</p>
```

Both apostrophes and both dashes there are the curly and em variants a CMS emits, which is
to say: every real page.

```
$ python3 tools/deslop.py page.html
  score 5/5  CLEAN                      # ← two rules blind

$ python3 tools/deslop.py --text "<same copy>"
  AI constructions:
    · the 'it's not just X, it's Y' construction  (1)
    · the 'whether you're X or Y' opener  (1)
  score 4/5  needs a cleanse
```

This is the empty-input case the module docstring already warns about — *"a gate that stamps
an empty file CLEAN reports slop as clean at exactly the moment the pipeline broke"* —
arriving through a different door. `--text` was always correct; the file path was the blind
spot, and the file path is what `.github/workflows/slop.yml` wires into CI.

## The second half

Reading correctly then exposes the other end of the pipe. Real non-ASCII now reaches
`print()`, and stdout is still `cp1252`, so one CJK character or emoji inside a flagged
snippet ends the run in a `UnicodeEncodeError` traceback instead of a score. Fixing only
the read trades a silent-pass bug for a crash — and the suite already asserts
`missing file has no traceback`, so tracebacks are clearly out of scope for this tool.

`sys.stdout.reconfigure(errors='replace')` keeps the console's own encoding and drops the
unprintable character. Naming the tell is the job; echoing it byte-for-byte is not:

```
  punctuation cadence:
    · two or more em-dashes in one sentence  (Our seamless platform ?? — ?? — delivers…)
  score 3/5  needs a cleanse
```

## Tests

Two regression tests, both driven through the CLI on purpose. I confirmed they fail against
`main` before accepting the fix:

```
3 FAILED
  · utf-8 file is not decoded as cp1252: a UTF-8 page full of tells scored CLEAN
  · utf-8 file: construction rule fires: score 5/5  CLEAN
  · utf-8 file: em-dash rule fires: score 5/5  CLEAN
```

With the patch, `python3 tools/test_deslop.py` → `all tests passed` on Python 3.13.7 /
Windows (`cp1252`) and unchanged on the Linux CI job, where the locale already happened to
be UTF-8 and hid this.

No behaviour change on any platform where the locale was already UTF-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
