### PR TITLE
fix: rule 2 could not see contracted negations

### DIFF
--- a/tools/deslop.py
+++ b/tools/deslop.py
@@ -57,12 +57,28 @@ def _root_pattern(word):
         return rf"(?<!\w){re.escape(word)}(?!\w)"
     return rf"(?<!\w){re.escape(root)}(?:e|es|ed|ing|ion|ions|ional|ive|al|ally|s|ly|ness)?(?!\w)"
 
+# Negated "just/only/merely/simply", in either register.
+#
+# `\bnot\b` cannot match inside `isn't` — there is no standalone `not` token there — so
+# an uncontracted-only pattern misses every contracted form, which is the register a
+# model reaches for when it is trying hardest to sound human. Matching the `n't` suffix
+# covers isn't / aren't / wasn't / doesn't / don't / won't / can't without enumerating
+# them. Straight and curly apostrophes both.
+_NEG_JUST = r"(?:\bnot|n['’]t)\s+(?:just|only|merely|simply)\b"
+
+# The Y clause of the swap, reached across a comma or a single full stop. It is not
+# always a copula — "it doesn't just park you, it GETS you there" is the same move — so
+# this takes a pronoun subject and lets any verb follow. The punctuation carries the
+# precision: "It's not just about money." has no Y clause and stays clean, and so does
+# "Do not just take my word for it."
+_XY_TAIL = r"[^!?]{0,80}?[,.]\s*(?:it|this|that|they|we|you|he|she|i)\b"
+
 PHRASES = [
     # constructions, not words — these are the loudest tells
     # The contracted and uncontracted forms both matter: formal register is not an
     # adversarial rewrite, it is the default thing a model emits.
-    (r"\bnot (just|only|merely|simply)\b[^.!?]{0,80}\bbut\b", "the 'not just X, but Y' construction"),
-    (r"\bit(?:'?s| is) not (only|just)\b[^.!?]{0,80}\bit(?:'?s| is)\b", "the 'it's not just X, it's Y' construction"),
+    (_NEG_JUST + r"[^.!?]{0,80}\bbut\b", "the 'not just X, but Y' construction"),
+    (_NEG_JUST + _XY_TAIL, "the 'not just X, it's Y' construction"),
     (r"\bwhether you(?:'?re| are)\b[^.!?]{0,40}\bor\b", "the 'whether you're X or Y' opener"),
     (r"\bmore than just\b",                        "'more than just'"),
     (r"\b(that|this)(?:'?s| is) where\b[^.!?]{0,30}\bcomes? in\b", "'that's where X comes in'"),

--- a/tools/test_deslop.py
+++ b/tools/test_deslop.py
@@ -165,6 +165,28 @@ for clean in ('"Don\'t Make Me Think", 2000. The reader decides in seconds.',
               'Version 2.0. Readers can skip it.'):
     check('proof does not reach across a full stop', not PROOF.search(clean), clean)
 
+# ── negated "just": the contracted register counts too ──────────────────────
+# `\bnot\b` has no standalone token to match inside `isn't`, so an uncontracted-only
+# pattern scored every contracted form clean — in the register a model reaches for
+# when it is trying hardest to sound human. The full stop cases matter as much: the
+# window could not previously cross one.
+for hit in ("This isn't just a map, it's a plan.",
+            'It is not just a map. It is a plan.',
+            "SlopMonster isn't just a linter, it's a gate.",
+            "These aren't just words, they're tells.",
+            'This is not just a map, but a plan.',
+            "It doesn't just score you, it fails the build."):
+    check('negated-just construction caught', 'phrases' in groups(hit), hit)
+
+# Paired must-stay-clean cases, per this file's rule. The Y clause needs a comma or a
+# full stop before its pronoun, which is what stops a bare negation tripping the rule.
+for clean in ("It's not just about money.",
+              'Do not just take my word for it.',
+              'We could not just sit there. The rain kept falling.',
+              'The lot is not paved, it is grass.',
+              'He said the price was not right, and we walked away.'):
+    check('negated-just stays clean', 'phrases' not in groups(clean), clean)
+
 if fails:
     print(f'{len(fails)} FAILED\n')
     for f in fails:


### PR DESCRIPTION
## The bug

`\bnot\b` has no standalone token to match inside `isn't`, so rule 2's uncontracted-only pattern scored every contracted form of the construction **clean**. That is the register a model reaches for when it is trying hardest to sound human, which makes it the form most worth catching.

The comment directly above the rule already says the contracted forms matter — the regex just did not implement it.

Scoring `5/5 CLEAN` on `main` today:

```
This isn't just a map, it's a plan.
These aren't just words, they're tells.
It doesn't just score you, it fails the build.
It is not just a map. It is a plan.
```

The last line is a second, smaller gap: `[^.!?]{0,80}` cannot cross a full stop, so the split-sentence form of the same swap was invisible too.

## The fix

Two named constants replace the two inline patterns.

`_NEG_JUST` matches the `n't` suffix directly, which covers isn't / aren't / wasn't / doesn't / don't / won't / can't without enumerating them. Straight and curly apostrophes both.

`_XY_TAIL` reaches the Y clause across a comma or a single full stop, and takes a pronoun subject with any verb after it. The Y clause is not always a copula — *"it doesn't just park you, it **gets** you there"* is the same move, and an earlier draft of this patch missed it because I required `is`/`'s`.

## Precision

The comma or full stop before the pronoun is what carries precision, so a bare negation does not trip the rule. These still score clean and ship as the paired cases the test file's docstring asks for:

```
It's not just about money.
Do not just take my word for it.
We could not just sit there. The rain kept falling.
The lot is not paved, it is grass.
He said the price was not right, and we walked away.
```

## Verification

- Existing suite passes unmodified.
- 11 new cases in `tools/test_deslop.py`, paired hit and stay-clean.
- `README.md`, `SKILL.md`, `references/principles.md`, `references/signs-of-ai-writing.md` and `examples/ridgeline-roofing.md` all still score `5/5 CLEAN` — no new false positives on the repo's own prose.

Two files, +40 / -2.

Thanks for the tool — the linter-gets-the-last-word framing is the part that made it worth installing over the model-judges-itself alternatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)