### PR TITLE
Read every input as UTF-8, and normalise all of them

### DIFF
--- a/tools/deslop.py
+++ b/tools/deslop.py
@@ -107,6 +107,21 @@ PROOF = re.compile(
     re.I)
 
 
+def normalise(t):
+    """Fold the typographic variants back to the plain ones the rules match.
+
+    A non-breaking hyphen is not `-`, \xa0 is not a space, and a curly
+    apostrophe is not `'`. Miss any of them and `cutting-edge`,
+    `it's not just X` and `whether you're` all stop matching on real copy,
+    because real copy is exactly where the pretty characters come from.
+
+    Every input path runs through here. Markdown skipped it once, and the
+    construction rules went blind on every .md file with a smart quote in it.
+    """
+    t = t.replace('‑', '-').replace('\xa0', ' ').replace('’', "'")
+    return re.sub(r'\s+', ' ', t).strip()
+
+
 def visible_text(html):
     """What a visitor actually reads. Script/style stripped, tags removed."""
     t = re.sub(r'<(script|style)\b.*?</\1>', ' ', html, flags=re.S | re.I)
@@ -117,10 +132,23 @@ def visible_text(html):
     # punctuation rule, and every apostrophe-encoded page went blind to the
     # `it's not just X` and `whether you're` patterns.
     t = _html.unescape(t)
-    # unescape maps &#8209; to a non-breaking hyphen and &nbsp; to \xa0, neither
-    # of which match `cutting-edge` or a plain space. Curly apostrophe likewise.
-    t = t.replace('‑', '-').replace('\xa0', ' ').replace('’', "'")
-    return re.sub(r'\s+', ' ', t).strip()
+    return normalise(t)
+
+
+def read_utf8(path):
+    """Read a file as UTF-8, whatever the machine's locale says.
+
+    open() with no encoding= uses the locale's, which is cp1252 on a stock
+    Windows install. A UTF-8 page then decodes its em-dashes and curly
+    apostrophes into mojibake, .replace('\u2019', "'") never fires, and
+    window.count('\u2014') counts zero. The punctuation and construction rules
+    go silently blind: the same copy scores 4/5 through --text and 5/5 CLEAN
+    from a file path, and the file path is what CI wires in.
+
+    A gate that passes because it cannot read is worse than no gate at all.
+    Reported by @Azrael259 in #3, who hit it on Windows.
+    """
+    return open(path, encoding='utf-8', errors='replace').read()
 
 
 def markdown_prose(md):
@@ -157,7 +185,7 @@ def markdown_prose(md):
     md = re.sub(r'^\s*(?:[-*+]|\d+\.)\s+', ' . ', md, flags=re.M)
     md = re.sub(r'^\s*>\s?', ' . ', md, flags=re.M)
     md = re.sub(r'[*_>]', ' ', md)
-    return re.sub(r'\s+', ' ', md).strip()
+    return normalise(md)
 
 
 def audit(text):
@@ -261,6 +289,16 @@ def report(hits, label='', allow_proof=False):
 
 
 if __name__ == '__main__':
+    # Reading UTF-8 correctly means real non-ASCII now reaches print(), and a
+    # Windows console is cp1252: one CJK character or emoji inside a flagged
+    # snippet would end the run in a UnicodeEncodeError traceback. Replace
+    # rather than raise. Naming the tell is the job; echoing it byte-for-byte
+    # is not, and the suite already asserts this tool never shows a traceback.
+    try:
+        sys.stdout.reconfigure(errors='replace')
+    except (AttributeError, ValueError):      # already-wrapped or exotic stream
+        pass
+
     args = sys.argv[1:]
     if not args:
         sys.exit(__doc__)
@@ -277,12 +315,12 @@ if __name__ == '__main__':
             text = markdown_prose(text)
     elif args[0].endswith('.md') or as_md:
         try:
-            text = markdown_prose(open(args[0]).read())
+            text = markdown_prose(read_utf8(args[0]))
         except (FileNotFoundError, IsADirectoryError, PermissionError) as e:
             sys.exit(f'deslop: cannot read {args[0]}: {e.strerror}')
     else:
         try:
-            html = open(args[0]).read()
+            html = read_utf8(args[0])
         except (FileNotFoundError, IsADirectoryError, PermissionError) as e:
             sys.exit(f'deslop: cannot read {args[0]}: {e.strerror}')
         if '--view' in args:

--- a/tools/test_deslop.py
+++ b/tools/test_deslop.py
@@ -8,6 +8,7 @@ must-stay-clean case that would break if the rule got greedy.
 import re
 import subprocess
 import sys
+import tempfile
 import os
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -97,6 +98,38 @@ r = subprocess.run([sys.executable, f'{here}/deslop.py', '/nope/missing.html'],
                    capture_output=True, text=True)
 check('missing file exits non-zero', r.returncode != 0, f'exit {r.returncode}')
 check('missing file has no traceback', 'Traceback' not in r.stderr, r.stderr[:80])
+
+# ── files are read as UTF-8, whatever the locale ───────────────────────────
+# open() with no encoding= uses the locale's, cp1252 on a stock Windows box. A
+# UTF-8 page then decodes to mojibake and the em-dash and construction rules
+# never fire, so a page full of tells scores CLEAN. Driven through the CLI on
+# purpose: --text was always fine, the file paths were the blind spot. Both of
+# them: .html goes through visible_text, .md through markdown_prose.
+_dir = tempfile.mkdtemp()
+_tells = ('It\u2019s not just a tool, it\u2019s a platform. Whether you\u2019re a startup '
+          'or an agency, we ship fast \u2014 really fast \u2014 every week.')
+
+for name, body in (('utf8.html', f'<html><body><p>{_tells}</p></body></html>'),
+                   ('utf8.md', _tells)):
+    path = os.path.join(_dir, name)
+    with open(path, 'w', encoding='utf-8') as fh:
+        fh.write(body)
+    r = subprocess.run([sys.executable, f'{here}/deslop.py', path],
+                       capture_output=True, text=True, encoding='utf-8', errors='replace')
+    check(f'{name} is not decoded as cp1252', r.returncode != 0,
+          'a UTF-8 page full of tells scored CLEAN - locale decoding is back')
+    check(f'{name}: construction rule fires', 'construction' in r.stdout, r.stdout[:140])
+    check(f'{name}: em-dash rule fires', 'em-dash' in r.stdout, r.stdout[:140])
+
+# A flagged snippet outside the console codepage must score, not traceback.
+_cjk = os.path.join(_dir, 'cjk.html')
+with open(_cjk, 'w', encoding='utf-8') as fh:
+    fh.write('<html><body><p>Our seamless platform \u4f60\u597d \u2014 \u4e16\u754c '
+             '\u2014 delivers robust value today.</p></body></html>')
+r = subprocess.run([sys.executable, f'{here}/deslop.py', _cjk],
+                   capture_output=True, text=True, encoding='utf-8', errors='replace')
+check('non-cp1252 snippet does not traceback', 'Traceback' not in r.stderr, r.stderr[-160:])
+check('non-cp1252 snippet still scores', 'score' in r.stdout, r.stdout[:140])
 
 # ── clean human copy still scores 5/5 ───────────────────────────────────────
 for ok in ('Six nails per shingle, every shingle.',


### PR DESCRIPTION
Takes the fix from #3 by @Azrael259 and finishes it.

## The bug they found

On a stock Windows install `deslop.py` scored a page full of tells **5/5 CLEAN**. No error. It passed.

`open()` with no `encoding=` uses the locale's, which is `cp1252` on Windows. A UTF-8 page decodes its em-dashes and curly apostrophes into mojibake, so the punctuation and construction rules match nothing.

Reproduced here, same file, two ways to read it:

| Read as | Groups fired | Em-dashes counted |
|---|---|---|
| UTF-8 | constructions, punctuation | 2 |
| cp1252 | none | 0 |

A gate that passes because it cannot read is worse than no gate.

## Why not merge #3 directly

It predated the markdown reader, so it covered one of the two file paths. Both now go through a single `read_utf8()`.

## The second bug, found by writing the test

`markdown_prose()` never ran the typographic normalisation `visible_text()` did. So a smart quote in any `.md` file blinded the construction rules in exactly the same way the encoding bug did, on a completely different code path. That fold is now a shared `normalise()` every input path runs through.

That one was mine, not theirs.

## Also

`sys.stdout.reconfigure(errors='replace')`, kept from #3. Reading UTF-8 correctly means CJK and emoji reach `print()`, and a cp1252 console would turn a score into a `UnicodeEncodeError` traceback. The suite already asserts this tool never shows a traceback.

## Checks

- `python3 tools/test_deslop.py` passes. New tests cover `.html` and `.md`, and assert a non-cp1252 snippet still scores rather than crashing.
- All 7 tracked `.md` files still score 5/5.

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)