### PR TITLE
Split the model's change notes out of the cleansed copy

### DIFF
--- a/.github/workflows/slop.yml
+++ b/.github/workflows/slop.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Regression tests
         run: python3 tools/test_deslop.py
 
+      # The copy/notes split is what keeps the model's change notes out of
+      # cleansed.md. No model calls, so it runs here like any other unit test.
+      - name: Cleanse split tests
+        run: bash tools/test_cleanse.sh
+
       # This is the gate itself, copied as-is into your own repo: point it at
       # whatever file holds your shipped copy. Non-zero below 5/5 fails the build.
       - name: Lint the shipped copy

--- a/SKILL.md
+++ b/SKILL.md
@@ -66,11 +66,22 @@ runs on a **different model family** than the one that wrote the draft:
 | No CLI at all | — | `cleanse.sh` prints the prompt; paste it into the other family's chat |
 
 ```bash
-tools/cleanse.sh draft.md > cleansed.md      # time-bound, exits 124 on hang
+tools/cleanse.sh draft.md > cleansed.md                 # copy out, notes on stderr
+tools/cleanse.sh draft.md > cleansed.md 2> notes.txt    # keep the notes as well
 ```
 
 The instruction it carries (`prompts/cleanse.txt`): strip the tells, keep every fact,
-keep the length within 10%, invent nothing, return only the copy.
+keep the length within 10%, invent nothing.
+
+It returns **two things**. The rewritten copy, then a `<<<SLOPMONSTER-NOTES>>>` line, then up
+to five bullets naming each tell and its fix. The script splits them, so **stdout is copy and
+stderr is notes**, and the redirect above writes prose only.
+
+Read the notes. PASS 2 tells the model to stop at the last real point, so it will sometimes
+delete your closing line, and the notes are the only place it says so.
+
+`WARNING no <<<SLOPMONSTER-NOTES>>> line` means the model ignored the format and the whole
+reply came through as copy. Check the tail before you ship.
 
 ## Step 4 — Re-lint
 

--- a/prompts/cleanse.txt
+++ b/prompts/cleanse.txt
@@ -40,7 +40,13 @@ ABSOLUTE RULES
 - Preserve any HTML tags, markdown structure and placeholders exactly as they appear.
 
 OUTPUT
-Return the rewritten copy in full, and nothing before it. Then a line "---", then at most five
-bullets naming the tell and the fix. No preamble, no restatement of these instructions.
+Return the rewritten copy in full, and nothing before it. Then a line containing exactly
+<<<SLOPMONSTER-NOTES>>>
+and nothing else, then at most five bullets naming the tell and the fix. No preamble, no
+restatement of these instructions.
+
+That sentinel line is parsed by a script. Emit it exactly once, alone on its line, with no
+bullet, quotes or backticks around it, even when you changed nothing. Everything above it is
+published as copy; everything below it is shown to the author as notes.
 
 TEXT TO EDIT:

--- a/tools/cleanse.sh
+++ b/tools/cleanse.sh
@@ -41,6 +41,46 @@ $DRAFT"
 
 find_bin() { command -v "$1" 2>/dev/null || { [ -x "$HOME/.local/bin/$1" ] && echo "$HOME/.local/bin/$1"; }; }
 
+# The reply is the copy, then a sentinel line, then the change notes. Copy goes to
+# STDOUT so the documented `cleanse.sh draft.md > cleansed.md` writes prose ONLY;
+# the notes go to STDERR so you still read them.
+#
+# Splitting on the old bare `---` was not possible: `---` is a legal markdown
+# horizontal rule and a YAML frontmatter delimiter, so any draft that contained one
+# got cut at the wrong place. Without a split the notes landed inside cleansed.md,
+# and step 4 then scored the model's own commentary as prose and stamped it CLEAN —
+# the gate reporting a clean page at exactly the moment it was measuring the wrong
+# bytes. Redirecting to a file and reading only that file is the documented flow, so
+# the leak was invisible until you opened the output.
+#
+# Fails OPEN on content: no sentinel means print the whole reply as copy and warn.
+# A stray note you can see and delete; a silently swallowed last paragraph you cannot.
+NOTES_SENTINEL='<<<SLOPMONSTER-NOTES>>>'
+
+emit_copy() {
+  awk -v s="$NOTES_SENTINEL" '
+    $0 == s { seen = 1; next }
+    seen    { notes = notes $0 "\n"; next }
+            { body = body $0 "\n" }
+    END {
+      if (!seen) {
+        printf "%s", body
+        print "cleanse: WARNING no " s " line in the reply." > "/dev/stderr"
+        print "cleanse: emitting everything as copy. Check the tail before you ship," > "/dev/stderr"
+        print "cleanse: because change notes may be scored as prose by the re-lint." > "/dev/stderr"
+        exit 0
+      }
+      sub(/\n+$/, "", body)          # drop the blank lines that preceded the sentinel
+      printf "%s\n", body
+      if (notes != "") {
+        print ""                       > "/dev/stderr"
+        print "cleanse: what changed -" > "/dev/stderr"
+        printf "%s", notes             > "/dev/stderr"
+      }
+    }
+  '
+}
+
 CODEX="$(find_bin codex || true)"
 CLAUDE="$(find_bin claude || true)"
 
@@ -73,13 +113,17 @@ if [ -n "$CODEX" ] && [ "${DESLOP_WRITER:-claude}" != "gpt" ]; then
   # structure exactly" instruction the prompt file gives.
   BODY="$(printf '%s\n' "$RAW" | awk '$0=="codex"{buf="";on=1;next} $0=="tokens used"{on=0;next} on{buf=buf $0 "\n"} END{printf "%s", buf}')"
   if [ -n "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
-    printf '%s\n' "$BODY"
+    printf '%s\n' "$BODY" | emit_copy
   else
-    printf '%s\n' "$RAW"
+    printf '%s\n' "$RAW" | emit_copy
   fi
 elif [ -n "$CLAUDE" ] && [ "${DESLOP_WRITER:-claude}" = "gpt" ]; then
   # GPT wrote the draft -> Claude cleanses it.
-  run_bounded "$CLAUDE" -p "$FULL"
+  # Captured before the split, not piped straight into it: a pipeline reports the
+  # LAST command's status, so a timeout would have returned emit_copy's 0 and the
+  # 124 contract would have been lost.
+  CLAUDE_OUT="$(run_bounded "$CLAUDE" -p "$FULL")" || exit $?
+  printf '%s\n' "$CLAUDE_OUT" | emit_copy
 else
   # Reached when the only CLI available is the same family that wrote the draft.
   # Running that would be a model marking its own homework, which is the one

--- a/tools/test_cleanse.sh
+++ b/tools/test_cleanse.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression tests for the copy/notes split in cleanse.sh.
+#
+# The split is what keeps the model's change notes out of cleansed.md. Without it
+# step 4 re-lints the notes as if they were prose and reports CLEAN, which is the
+# gate lying at the one moment you are relying on it.
+#
+# Sources emit_copy out of cleanse.sh rather than reimplementing it, so this test
+# fails if the real function drifts. No model calls, so it runs in CI.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+eval "$(sed -n "/^NOTES_SENTINEL=/,/^}$/p" "$HERE/cleanse.sh")"
+
+fail=0
+check() {  # check <name> <condition-result>
+  if [ "$2" = "0" ]; then printf '  ok    %s\n' "$1"
+  else printf '  FAIL  %s\n' "$1"; fail=1; fi
+}
+
+# ── the ordinary reply ──────────────────────────────────────────────────────
+out="$(printf 'Line one.\nLine two.\n\n%s\n- killed a tell\n' "$NOTES_SENTINEL" | emit_copy 2>/dev/null)"
+[ "$out" = "$(printf 'Line one.\nLine two.')" ]; check 'copy is the text above the sentinel' $?
+err="$(printf 'Copy.\n\n%s\n- killed a tell\n' "$NOTES_SENTINEL" | emit_copy 2>&1 >/dev/null)"
+case "$err" in *'killed a tell'*) check 'notes go to stderr' 0;; *) check 'notes go to stderr' 1;; esac
+case "$out" in *'killed a tell'*) check 'notes stay OUT of stdout' 1;; *) check 'notes stay OUT of stdout' 0;; esac
+
+# ── a draft that legitimately contains --- ──────────────────────────────────
+# The old separator was a bare `---`, which is both a markdown rule and a YAML
+# frontmatter delimiter, so splitting on it truncated any draft containing one.
+body="$(printf 'Intro.\n\n---\n\nAfter the rule.\nFinal line.\n\n%s\n- a note\n' "$NOTES_SENTINEL" | emit_copy 2>/dev/null)"
+case "$body" in *'Final line.'*) check 'copy past a --- survives' 0;; *) check 'copy past a --- survives' 1;; esac
+case "$body" in *'---'*) check 'the --- itself is preserved' 0;; *) check 'the --- itself is preserved' 1;; esac
+case "$body" in *'a note'*) check 'notes not leaked past a ---' 1;; *) check 'notes not leaked past a ---' 0;; esac
+
+# ── no sentinel: fail OPEN, never eat the copy ──────────────────────────────
+out="$(printf 'Only copy.\nSecond line.\n' | emit_copy 2>/dev/null)"
+case "$out" in *'Second line.'*) check 'missing sentinel keeps all copy' 0;; *) check 'missing sentinel keeps all copy' 1;; esac
+err="$(printf 'Only copy.\n' | emit_copy 2>&1 >/dev/null)"
+case "$err" in *WARNING*) check 'missing sentinel warns loudly' 0;; *) check 'missing sentinel warns loudly' 1;; esac
+
+# ── sentinel with nothing after it ──────────────────────────────────────────
+err="$(printf 'Copy only.\n\n%s\n' "$NOTES_SENTINEL" | emit_copy 2>&1 >/dev/null)"
+[ -z "$err" ]; check 'empty notes print nothing to stderr' $?
+
+# ── the blank lines before the sentinel are not published ───────────────────
+# The model separates the sentinel from the copy with a blank line. Without the
+# trim, every cleansed file ends in trailing whitespace.
+# Asserted through a FILE, not "$(...)": command substitution strips trailing
+# newlines, so a $()-based check cannot see this bug at all and passes either way.
+tmp="$(mktemp)"
+printf 'Copy ends here.\n\n\n%s\n- a note\n' "$NOTES_SENTINEL" | emit_copy 2>/dev/null >"$tmp"
+[ "$(wc -c <"$tmp" | tr -d ' ')" = "16" ]; check 'blank lines before the sentinel are trimmed' $?
+rm -f "$tmp"
+
+# ── the sentinel must not match when quoted inside prose ────────────────────
+out="$(printf 'We use the `%s` marker.\nStill copy.\n' "$NOTES_SENTINEL" | emit_copy 2>/dev/null)"
+case "$out" in *'Still copy.'*) check 'sentinel inside a line is not a split point' 0;; *) check 'sentinel inside a line is not a split point' 1;; esac
+
+[ "$fail" = "0" ] && echo "all cleanse tests passed" || { echo "cleanse tests FAILED"; exit 1; }


### PR DESCRIPTION
Found this running the skill end to end. The linter and the cleanse are both solid on their own; the seam between them leaks.

## The bug

`tools/cleanse.sh draft.md > cleansed.md` is the documented command, and the model's change notes land in `cleansed.md` along with the copy. Here is a real run on a throwaway draft, against `153fab34`:

```
## Why our platform matters

Our reliable platform makes your workflow simpler and better [needs number].

---

Whether you're a beginner or a seasoned pro, this approach supports your creative
work [needs number]. We use advanced technology to deliver significant results
[needs number]. And it doesn't get in your way.

The final line must survive this test.

---

- Removed stock phrases and inflated vocabulary.
- Replaced the "doesn't just" construction with a direct claim.
- Added `[needs number]` where the source provides no evidence.
- Varied sentence length and kept a deliberate rough edge.
```

stderr was **0 bytes**, so nothing warned. Step 4 then re-lints that file and scores the bullets as prose: it counted **95 words, of which 57 are copy and 38 are the model's commentary**. Roughly 40% of what the gate measured was not the copy. On another draft the leaked notes came back a confident **5/5 CLEAN**; here they dragged it to 4/5. Which way it lands depends on the notes' own vocabulary, and that is the problem: the score is partly a function of text that will never ship.

Because the documented flow is to redirect and read the output file, nothing surfaces this until you open it, and a straight pipe to publish would publish the changelog.

There is a second bite. `SKILL.md` says the prompt returns "only the copy", so the notes read as a malfunction rather than the format. They are not: `prompts/cleanse.txt` asks for them. But buried in the gated file, nobody reads them, and **the notes are the only place the model discloses what it removed**. PASS 2 says "stop at the last real point", so it will sometimes delete a closing line and mention that only in the block the pipeline treats as body text.

## Root cause

The separator. The prompt asked the model to end with a bare `---`, which is both a legal markdown horizontal rule and a YAML frontmatter delimiter. Note the output above now contains **two** `---`: the draft's own rule and the separator. No naive split can tell them apart, and splitting on the first one truncates the copy. So the notes could not be separated, and the docs drifted to match the behaviour instead of the contract.

## The fix

- **`prompts/cleanse.txt`** — separate with a `<<<SLOPMONSTER-NOTES>>>` sentinel line. Kept terse, since this text ships to the model on every run; the rationale lives in the code comment.
- **`tools/cleanse.sh`** — new `emit_copy` splits on that sentinel: **copy to stdout, notes to stderr**, so the documented redirect writes prose only and you still see what changed.
  - **Fails open on content.** No sentinel means print the whole reply as copy and warn loudly. A stray note is visible and deletable; a silently swallowed last paragraph is not.
  - The `claude` branch now captures before piping. A pipeline reports the last command's status, so piping `run_bounded` straight into the splitter would have returned `emit_copy`'s 0 and lost the 124-on-timeout contract.
- **`SKILL.md`** — corrected. Documents both streams, and warns that the model sometimes deletes a closing line and says so only in the notes.
- **`tools/test_cleanse.sh`** — 11 assertions over `emit_copy`, sourced out of `cleanse.sh` with `sed` so it fails if the real function drifts. No model calls, so it is wired into the existing workflow.

## Verification

`test_deslop.py` and `test_cleanse.sh` both green, gate sample still 5/5.

Mutation-tested, because a shell test that never fails is worse than none. Four mutations of `emit_copy`, each applied to a snapshot of the fixed file, with the unmutated baseline confirmed green either side:

| Mutation | Result |
|---|---|
| notes written to stdout (the original bug) | RED |
| sentinel reverted to `---` | RED |
| fail-closed instead of fail-open | RED |
| trailing-blank trim removed | RED |

That last one initially **survived**. The assertion used `"$(...)"`, and command substitution strips trailing newlines, so it was structurally incapable of seeing the bug and passed either way. It now asserts a byte count through a file.

Same draft as above, re-run on this branch: exit 0, both `---` handling and the final line intact, **zero commentary in the gated file**, notes on stderr, and the copy goes 3/5 to 5/5.

Not included: I also widened the `PROOF` noun list locally, because `trusted by 10,000 photographers` scores 5/5 CLEAN while your own documented example `trusted by 10,000 teams` fires. Happy to send that separately if useful, but it is a different concern and I did not want to muddy this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)