### PR TITLE
Close the PROOF noun boundary, fix the README's safe tricolon example, note English-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ python3 tools/deslop.py index.html --allow-proof
 python3 tools/test_deslop.py
 ```
 
+The catalogue is English only. Copy in another language scores 5/5 because the scorer
+cannot read it, not because it is clean.
+
 No dependencies. The scorer is stdlib Python. The cleanse script needs one AI CLI
 (`codex` or `claude`), or neither, in which case it prints the prompt for you to paste.
 `.github/workflows/slop.yml` is the build gate, ready to copy into your own repo.
@@ -188,9 +191,9 @@ This check is deliberately narrow, and only two shapes fire it. With the Oxford 
 needs three single words. Without it, the third item has to be a short phrase that ends the
 clause.
 
-The narrowness is the point. "Inspection, repair and replacement for homes" is three real
-things a roofer does. Flagging that would be crying wolf, and the next person would turn
-the scorer off.
+The narrowness is the point. "Inspection, repair and replacement for homes and commercial
+buildings" is three real things a roofer does, and it scores clean. Flagging that would be
+crying wolf, and the next person would turn the scorer off.
 
 > ~~Trusted, reliable and built to last.~~
 > **Six nails per shingle, every shingle.**

--- a/tools/deslop.py
+++ b/tools/deslop.py
@@ -119,7 +119,11 @@ PROOF = re.compile(
     r"((?:happy|early|active|satisfied|verified|trusted|delighted)\s+)?"
     r"(?:\w+\s+){0,1}"
     r"(users?|customers?|learners?|students?|teams?|members?|companies|businesses"
-    r"|homeowners?|subscribers?|clients?|patients?|readers?|sites?|projects?)",
+    r"|homeowners?|subscribers?|clients?|patients?|readers?|sites?|projects?)"
+    # Closed with a word boundary, like `_root_pattern`. Without it `sites?`
+    # matched inside "sitemaps", `teams?` inside "teamsters" and `projects?`
+    # inside "projectors", and "12 sitemaps" scored as invented social proof.
+    r"(?!\w)",
     re.I)
 
 
@@ -254,9 +258,11 @@ def audit(text):
     # Without it, the third item must be a 2–3 word phrase that ends the clause:
     # "Trusted, reliable and built to last". That phrase requirement is what
     # separates a rhetorical flourish from a plain list of services —
-    # "Inspection, repair and replacement for homes" is three real things a
-    # roofer does, and flagging it would be exactly the wolf-crying that gets a
-    # linter switched off.
+    # "Inspection, repair and replacement for homes and commercial buildings"
+    # is three real things a roofer does, its third item runs long, and
+    # flagging it would be exactly the wolf-crying that gets a linter switched
+    # off. Note the shape is what is judged, not the meaning: a three-word
+    # closing item ("replacement for homes") does fire, by design.
     for pat in (r'\b(\w{4,}),\s+(\w{4,}),\s+and\s+(\w{4,})\b',
                 r'\b(\w{4,}),\s+(\w{4,})\s+and\s+((?:\w+\s+){1,2}\w+)\s*[.!?,;:]'):
         for m in re.finditer(pat, text):

--- a/tools/test_deslop.py
+++ b/tools/test_deslop.py
@@ -220,6 +220,25 @@ for clean in ("It's not just about money.",
               'He said the price was not right, and we walked away.'):
     check('negated-just stays clean', 'phrases' not in groups(clean), clean)
 
+# ── proof nouns need a closing boundary ─────────────────────────────────────
+# `sites?` matched inside "sitemaps", `teams?` inside "teamsters". Real proof
+# claims must still fire; ordinary nouns that merely start with one must not.
+for clean in ('We generated 12 sitemaps last quarter.',
+              'The hall seats 20 projectors.',
+              'We shipped 40 userscripts.',
+              'The union sent 300 teamsters.'):
+    check('proof noun does not match inside a longer word', 'proof' not in groups(clean), clean)
+for hit in ('Trusted by 10,000 teams.', 'We host 12 sites.', 'Over 300 clients served.'):
+    check('proof claim still caught', 'proof' in groups(hit), hit)
+
+# ── the README's own must-not-fire tricolon example ─────────────────────────
+# The wolf-crying case the narrowness exists to prevent. If this fires, the
+# README is lying about the rule.
+check('README safe tricolon example stays clean',
+      'rhythm' not in groups('Inspection, repair and replacement for homes and commercial buildings.'))
+check('README tricolon example still fires',
+      'rhythm' in groups('Trusted, reliable and built to last.'))
+
 if fails:
     print(f'{len(fails)} FAILED\n')
     for f in fails:


### PR DESCRIPTION
Fixes #9.

- `PROOF` now closes with `(?!\w)`, like `_root_pattern`. `12 sitemaps`, `300 teamsters`, `20 projectors` and `40 userscripts` score clean. `trusted by 10,000 teams` still fires.
- The README's must-not-fire tricolon example was wrong: `replacement for homes` is a three-word closing phrase, which is the shape the second pattern is documented to catch. The README now quotes the line that actually shipped on Ridgeline, which scores clean. The code comment says the same.
- README notes the catalogue is English only.
- Bug 3 (change notes in the cleansed file) was fixed by #8.
- Regression tests for all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)